### PR TITLE
bug fix in verification handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,13 +181,13 @@ class VerificationHandler(BaseHandler):
     user, ts = self.user_model.get_by_auth_token(int(user_id), signup_token,
       'signup')
 
-    # store user data in the session
-    self.auth.set_session(self.auth.store.user_to_dict(user), remember=True)
-
     if not user:
       logging.info('Could not find any user with id "%s" signup token "%s"',
         user_id, signup_token)
       self.abort(404)
+    
+    # store user data in the session
+    self.auth.set_session(self.auth.store.user_to_dict(user), remember=True)
 
     if verification_type == 'v':
       # remove signup token, we don't want users to come back with an old link


### PR DESCRIPTION
Bug fix (although untested it should work).

If one tries to verify an account that has already been verified, signup_token will no longer exist, thus user will be none and webapp2.auth.set_session will fail (IMO this is a bug with webapp2 trying to access user['user_id'] when user is None)
